### PR TITLE
Fix IPv6 address parsing in cluster node presence check

### DIFF
--- a/internal/k8sutils/redis.go
+++ b/internal/k8sutils/redis.go
@@ -541,8 +541,18 @@ func getContainerID(ctx context.Context, client kubernetes.Interface, cr *rcvb2.
 func checkRedisNodePresence(ctx context.Context, cr *rcvb2.RedisCluster, nodeList []clusterNodesResponse, nodeName string) bool {
 	log.FromContext(ctx).V(1).Info("Checking if Node is in cluster", "Node", nodeName)
 	for _, node := range nodeList {
-		s := strings.Split(node[1], ":")
-		if s[0] == nodeName {
+		addrField := node[1]
+		if idx := strings.Index(addrField, ","); idx != -1 {
+			addrField = addrField[:idx]
+		}
+		if at := strings.Index(addrField, "@"); at != -1 {
+			addrField = addrField[:at]
+		}
+		host, _, err := net.SplitHostPort(addrField)
+		if err != nil {
+			host = addrField
+		}
+		if host == nodeName {
 			return true
 		}
 	}

--- a/internal/k8sutils/redis_test.go
+++ b/internal/k8sutils/redis_test.go
@@ -34,6 +34,16 @@ func TestCheckRedisNodePresence(t *testing.T) {
 		nodes = append(nodes, node)
 	}
 
+	ipv6Output := "abcd [2001:db8::1]:6379@16379,hostv6 master - 0 1 1 connected"
+	csvOutputV6 := csv.NewReader(strings.NewReader(ipv6Output))
+	csvOutputV6.Comma = ' '
+	csvOutputV6.FieldsPerRecord = -1
+	rawNodesV6, _ := csvOutputV6.ReadAll()
+	nodesV6 := make([]clusterNodesResponse, 0, len(rawNodesV6))
+	for _, node := range rawNodesV6 {
+		nodesV6 = append(nodesV6, node)
+	}
+
 	tests := []struct {
 		nodes []clusterNodesResponse
 		ip    string
@@ -42,6 +52,7 @@ func TestCheckRedisNodePresence(t *testing.T) {
 		{nodes, "172.17.0.24", true},
 		{nodes, "172.17.0.111", false},
 		{nodes, "172.17.0.2", false},
+		{nodesV6, "2001:db8::1", true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- handle IPv6 addresses when detecting redis nodes in the cluster
- add a unit test for IPv6 node detection

## Testing
- `go test ./internal/k8sutils -run TestCheckRedisNodePresence -count=1` *(fails: k8s modules cannot be downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_683fbd0bc4688324a9a7772aef75437c